### PR TITLE
fix(angular): set standalone: false for NgModule components

### DIFF
--- a/src/ui-persistent-bottomsheet/angular/module.ts
+++ b/src/ui-persistent-bottomsheet/angular/module.ts
@@ -17,7 +17,8 @@ export interface ItemEventArgs {
  */
 @Component({
     selector: 'BottomSheet',
-    template: '<ng-content></ng-content>'
+    template: '<ng-content></ng-content>',
+    standalone: false
 })
 export class BottomSheetComponent {
     public pbs: PersistentBottomSheet;
@@ -83,7 +84,8 @@ export class BottomSheetComponent {
  * Directive identifying the left drawer
  */
 @Directive({
-    selector: '[bottomSheet]'
+    selector: '[bottomSheet]',
+    standalone: false
 })
 export class BottomSheetDirective {
     constructor(@Inject(ElementRef) private _elementRef: ElementRef) {


### PR DESCRIPTION
Fixes build errors with Angular 14+ where components are treated as standalone by default

## How to reproduce

Run `npm run build.all` - it fails with Angular compilation errors.
Note: `npm run build` completes successfully without errors.