### PR TITLE
fix: honour panGestureOptions on the touch fallback path

### DIFF
--- a/src/ui-persistent-bottomsheet/index.ts
+++ b/src/ui-persistent-bottomsheet/index.ts
@@ -97,6 +97,9 @@ export class PersistentBottomSheet extends AbsoluteLayout {
 
     private lastTouchY: number;
     private touchStartY: number;
+    private touchStartX: number;
+    /** the touch went sideways, so it belongs to whatever is under the finger, not to the sheet */
+    private touchIsHorizontal = false;
     private wasDraggingPanel = false;
     private gestureModeDecided = false;
     private _translationY = -1;
@@ -438,12 +441,17 @@ export class PersistentBottomSheet extends AbsoluteLayout {
     vt: VelocityTracker | null = null;
     private onTouch(event: TouchGestureEventData) {
         let touchY;
+        let touchX;
         // touch event gives you relative touch which varies with translateY
         // so we use touch location in the window
         if (__ANDROID__) {
-            touchY = Utils.layout.toDeviceIndependentPixels((event.android as android.view.MotionEvent).getRawY());
+            const motionEvent = event.android as android.view.MotionEvent;
+            touchY = Utils.layout.toDeviceIndependentPixels(motionEvent.getRawY());
+            touchX = Utils.layout.toDeviceIndependentPixels(motionEvent.getRawX());
         } else if (__IOS__) {
-            touchY = (event.ios.touches.anyObject() as UITouch).locationInView(null).y;
+            const location = (event.ios.touches.anyObject() as UITouch).locationInView(null);
+            touchY = location.y;
+            touchX = location.x;
         }
         const p = event.getActivePointers()[0];
         if (event.action === 'down') {
@@ -451,6 +459,8 @@ export class PersistentBottomSheet extends AbsoluteLayout {
             this.vt.addMovement(p.getX(), p.getY());
             this.lastTouchY = null;
             this.touchStartY = touchY;
+            this.touchStartX = touchX;
+            this.touchIsHorizontal = false;
             this.wasDraggingPanel = false;
             this.gestureModeDecided = false;
         } else if (event.action === 'up' || event.action === 'cancel') {
@@ -478,6 +488,7 @@ export class PersistentBottomSheet extends AbsoluteLayout {
             this.touchStartY = null;
             // }
             this.lastTouchY = null;
+            this.touchIsHorizontal = false;
 
             // Reset dragging state on any end event
             this.wasDraggingPanel = false;
@@ -488,6 +499,8 @@ export class PersistentBottomSheet extends AbsoluteLayout {
                 this.vt = VelocityTracker.obtain();
                 this.lastTouchY = null;
                 this.touchStartY = touchY;
+                this.touchStartX = touchX;
+                this.touchIsHorizontal = false;
                 this.wasDraggingPanel = false;
                 this.gestureModeDecided = false;
             }
@@ -495,6 +508,31 @@ export class PersistentBottomSheet extends AbsoluteLayout {
 
             const deltaY = touchY - this.touchStartY;
             const absDeltaY = Math.abs(deltaY);
+
+            // This path is a plain touch listener, so the pan gesture handler options never reach it.
+            // Without them a horizontal drag over a child that pans or zooms - a chart, a pager -
+            // still flips us into panel dragging on the first pixel of vertical drift, and the
+            // cancelAllGestures() below then kills that child's handlers. So honour here the same
+            // options the caller passed for the gesture handler. Opt in: with no panGestureOptions
+            // nothing below changes
+            if (!this.wasDraggingPanel && this.panGestureOptions) {
+                const { failOffsetXEnd, failOffsetXStart, minDist } = this.panGestureOptions;
+                const deltaX = touchX - this.touchStartX;
+                if (
+                    this.touchIsHorizontal ||
+                    (failOffsetXEnd !== undefined && deltaX > failOffsetXEnd) ||
+                    (failOffsetXStart !== undefined && deltaX < failOffsetXStart)
+                ) {
+                    // one way for the rest of the touch, like the handler's own fail offsets
+                    this.touchIsHorizontal = true;
+                    this.lastTouchY = touchY;
+                    return;
+                }
+                if (minDist !== undefined && absDeltaY < minDist) {
+                    this.lastTouchY = touchY;
+                    return;
+                }
+            }
 
             // we cant have small movement ignore
             // otherwise the scrollview would slowly start moving


### PR DESCRIPTION
## Summary

`panGestureOptions` set on a `PersistentBottomSheet` are only applied to the pan **gesture handler**. The `onTouch` fallback path is a plain NativeScript `touch` listener and reads none of them, so a child that pans or zooms horizontally — a chart, a pager — could not keep its gesture: the sheet took the touch over and cancelled the child's handlers.

## The problem

`initGestures` attaches a touch listener on Android:

```ts
if (__ANDROID__ && this.bottomSheet) {
    this.bottomSheet.on('touch', this.onBottomSheetTouch, this);
}
```

In `onTouch`'s `move` branch, any movement flips the sheet into panel dragging:

```ts
const currentScrollY = this._scrollView ? this.scrollViewVerticalOffset : 0;
const isAtTop = currentScrollY === 0;
...
if (shouldStartDraggingPanel) {
    this.wasDraggingPanel = true;
    this.isScrollEnabled = false;
    this.cancelAllGestures();   // cancels every handler under the root view
}
```

With no `scrollView`, `currentScrollY` is hardcoded `0`, so `isAtTop` is **always** true. One pixel of vertical drift on a horizontal drag is enough — and with `deltaY === 0` the `else` branch fires too, as long as the panel is not fully expanded. `cancelAllGestures()` resolves to `rootView.tryCancelAllHandlers()`, killing the child's pan and pinch. It is a documented one-way transition, so the rest of the touch is lost and `onGestureState` early-returns on `wasDraggingPanel`.

Setting `failOffsetXEnd` / `minDist` on the sheet has no effect here, which is surprising: those options say exactly what should have happened.

## The fix

Track the horizontal delta alongside the vertical one, and apply the same options the caller already passes to the handler, before the `shouldStartDraggingPanel` block:

- past `failOffsetXEnd` / `failOffsetXStart` → mark the touch horizontal and stay out of the way for the rest of it, matching the one-way semantics of the native handler's fail offsets
- below `minDist` of vertical movement → do not take the gesture over yet

`lastTouchY` is still updated on every skipped move, so if the drag later turns vertical the first panel delta is one frame rather than the whole accumulated distance.

**Opt in:** the whole block is guarded on `this.panGestureOptions`, so a sheet without them behaves exactly as before. In particular the commented-out `SWIPE_DISTANCE_MINIMUM` check is left as it is — its comment documents a real reason (the scrollview creeping and then stealing the gesture), so only an explicitly requested `minDist` is honoured.

## Verification

- Verified on device (Android) in [Alpi Maps](https://github.com/Akylas/alpimaps): a chart inside the sheet regained pan and zoom, while a vertical drag over the same chart still drags the sheet.
- `tsc -d` emits cleanly. The only error is a pre-existing `TS2688: Cannot find type definition file for 'svelte-native'` from uninitialised submodules, unrelated to this change.
- No automated coverage — `release.yml` is the only workflow and there is no test runner, so this needs a manual pass. Suggested scenarios: a sheet with a horizontally pannable child and `panGestureOptions={{ failOffsetXEnd: 20, minDist: 40 }}`; a sheet with a `scrollViewId` (scroll then drag the panel, both directions); and a sheet with no `panGestureOptions` at all, to confirm nothing moved.

## Notes

- iOS reaches `onTouch` only through `onScrollViewTouch`, so a sheet with no `scrollViewId` was unaffected there — this reads as an Android-only bug, but the fix is platform independent.
- Present since at least 0.1.8; not a regression from a recent release.